### PR TITLE
Use a single RUN invocation

### DIFF
--- a/kernel-4.18.0-372.40.1.el8_6.iavf.bz2149746.bz2152493.marvell.x86_64/Containerfile
+++ b/kernel-4.18.0-372.40.1.el8_6.iavf.bz2149746.bz2152493.marvell.x86_64/Containerfile
@@ -33,8 +33,7 @@ RUN make all KVER=$(cat /kernel-version.txt)
 FROM quay.io/midu/side-kernel-4.18.0-372.40.1.el8_6.iavf.bz2149746.bz2152493.x86_64:latest
 COPY --from=builder /simple-kmod /simple-kmod
 WORKDIR /simple-kmod
-RUN make install KVER=$(rpm -qa kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}') && ostree container commit 
-
-#clean-up, delete the module build dir.
-RUN rm -rf /simple-kmod && ostree container commit
+RUN make install KVER=$(rpm -qa kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}') && \
+    rm -rf /simple-kmod && \
+    ostree container commit
 


### PR DESCRIPTION
With separate `RUN` lines, we'll still leak `/simple-kmod` into a layer, it will just appear to be removed later.